### PR TITLE
Implement attachment size calculation delay similar to the Jira Prometheus Exporter

### DIFF
--- a/src/main/java/ru/andreymarkelov/atlas/plugins/promconfluenceexporter/action/admin/SecureTokenConfigAction.java
+++ b/src/main/java/ru/andreymarkelov/atlas/plugins/promconfluenceexporter/action/admin/SecureTokenConfigAction.java
@@ -1,22 +1,57 @@
 package ru.andreymarkelov.atlas.plugins.promconfluenceexporter.action.admin;
 
 import com.atlassian.confluence.core.ConfluenceActionSupport;
+import ru.andreymarkelov.atlas.plugins.promconfluenceexporter.manager.ScheduledMetricEvaluator;
 import ru.andreymarkelov.atlas.plugins.promconfluenceexporter.manager.SecureTokenManager;
+
+import java.util.Date;
+import java.util.Map;
 
 public class SecureTokenConfigAction extends ConfluenceActionSupport {
     private SecureTokenManager secureTokenManager;
+    private ScheduledMetricEvaluator scheduledMetricEvaluator;
 
+    private final static String ERROR_INVALID_DELAY = "ru.andreymarkelov.atlas.plugins.promconfluenceexporter.admin.error.invalid.delay";
+    private final static String NOT_YET_EXECUTED = "ru.andreymarkelov.atlas.plugins.promconfluenceexporter.admin.settings.notyetexecuted";
+
+    private boolean saved = false;
     private String token;
+
+    private int delay;
+    private String lastExecutionTimestamp;
 
     @Override
     public String doDefault() throws Exception {
         token = secureTokenManager.getToken();
+        delay = scheduledMetricEvaluator.getDelay();
+        long temp = scheduledMetricEvaluator.getLastExecutionTimestamp();
+
+        if(temp > 0){
+            lastExecutionTimestamp = new Date(temp).toString();
+        } else {
+            lastExecutionTimestamp = getI18n().getText(NOT_YET_EXECUTED);
+        }
+
         return INPUT;
     }
 
     @Override
+    public void validate(){
+        if(delay <= 0){
+            addFieldError("delay", getI18n().getText(ERROR_INVALID_DELAY));
+        }
+    }
+
+    @Override
     public String execute() throws Exception {
+        if(hasErrors()){
+            return ERROR;
+        }
         secureTokenManager.setToken(token);
+        scheduledMetricEvaluator.setDelay(delay);
+        scheduledMetricEvaluator.restartScraping(delay);
+        setSaved(true);
+
         return SUCCESS;
     }
 
@@ -30,5 +65,29 @@ public class SecureTokenConfigAction extends ConfluenceActionSupport {
 
     public void setSecureTokenManager(SecureTokenManager secureTokenManager) {
         this.secureTokenManager = secureTokenManager;
+    }
+
+    public void setScheduledMetricEvaluator(ScheduledMetricEvaluator scheduledMetricEvaluator){
+        this.scheduledMetricEvaluator = scheduledMetricEvaluator;
+    }
+
+    public boolean isSaved() {
+        return saved;
+    }
+
+    public void setSaved(final boolean saved) {
+        this.saved = saved;
+    }
+
+    public int getDelay(){
+        return delay;
+    }
+
+    public void setDelay(int delay){
+        this.delay = delay;
+    }
+
+    public String getLastExecutionTimestamp() {
+        return lastExecutionTimestamp;
     }
 }

--- a/src/main/java/ru/andreymarkelov/atlas/plugins/promconfluenceexporter/manager/ScheduledMetricEvaluator.java
+++ b/src/main/java/ru/andreymarkelov/atlas/plugins/promconfluenceexporter/manager/ScheduledMetricEvaluator.java
@@ -1,6 +1,17 @@
 package ru.andreymarkelov.atlas.plugins.promconfluenceexporter.manager;
 
 public interface ScheduledMetricEvaluator {
+
     long getTotalAttachmentSize();
+
     int getTotalUsers();
+
+    long getLastExecutionTimestamp();
+
+    void restartScraping(int newDelay);
+
+    int getDelay();
+
+    void setDelay(int delay);
+
 }

--- a/src/main/resources/ru/andreymarkelov/atlas/plugins/promconfluenceexporter/i18n/prom-confluence-exporter.properties
+++ b/src/main/resources/ru/andreymarkelov/atlas/plugins/promconfluenceexporter/i18n/prom-confluence-exporter.properties
@@ -1,6 +1,14 @@
 ru.andreymarkelov.atlas.plugins.promconfluenceexporter.admin.section=Prometheus Exporter Settings
-ru.andreymarkelov.atlas.plugins.promconfluenceexporter.admin.section.desc=Setup security token for endpoint.
+ru.andreymarkelov.atlas.plugins.promconfluenceexporter.admin.section.desc=Setup security token and attachment size calculation delay for the prometheus endpoint.
 ru.andreymarkelov.atlas.plugins.promconfluenceexporter.admin.settings.title=Prometheus Exporter Settings
+ru.andreymarkelov.atlas.plugins.promconfluenceexporter.admin.settings.linkdesc=Exposed metrics are
+ru.andreymarkelov.atlas.plugins.promconfluenceexporter.admin.settings.link=here
 ru.andreymarkelov.atlas.plugins.promconfluenceexporter.admin.settings.actions.save=Save
 ru.andreymarkelov.atlas.plugins.promconfluenceexporter.admin.settings.token=Token
 ru.andreymarkelov.atlas.plugins.promconfluenceexporter.admin.settings.token.desc=Enter some text token which will be used to access the prometheus endpoint.
+ru.andreymarkelov.atlas.plugins.promconfluenceexporter.admin.settings.delay=Delay
+ru.andreymarkelov.atlas.plugins.promconfluenceexporter.admin.settings.delay.desc=Delay between successive attachment size calculations (in minutes).
+ru.andreymarkelov.atlas.plugins.promconfluenceexporter.admin.error.invalid.delay=Value for delay must be a positive integer.
+ru.andreymarkelov.atlas.plugins.promconfluenceexporter.admin.settings.lastexecution=Last execution:
+ru.andreymarkelov.atlas.plugins.promconfluenceexporter.admin.settings.notyetexecuted=not yet executed
+ru.andreymarkelov.atlas.plugins.promconfluenceexporter.admin.settings.status.success=Success

--- a/src/main/resources/ru/andreymarkelov/atlas/plugins/promconfluenceexporter/templates/actions/admin/settings.vm
+++ b/src/main/resources/ru/andreymarkelov/atlas/plugins/promconfluenceexporter/templates/actions/admin/settings.vm
@@ -7,7 +7,31 @@
     </head>
     <body>
         #parse ("/template/includes/actionerrors.vm")
+        <header class="aui-page-header">
+            <div class="aui-page-header-inner">
+                <div class="aui-page-header-main">
+                    <p>$i18n.getText("ru.andreymarkelov.atlas.plugins.promconfluenceexporter.admin.section.desc")</p>
+                    <p>
+                        <span class="aui-icon aui-icon-small aui-iconfont-info"></span>
+                        $action.getText("ru.andreymarkelov.atlas.plugins.promconfluenceexporter.admin.settings.linkdesc")
+                        <a target="_blank" href="/confluence/plugins/servlet/prometheus/metrics#if($!{token} != "")?token=${token}#end">$action.getText("ru.andreymarkelov.atlas.plugins.promconfluenceexporter.admin.settings.link")</a>.
+                    </p>
+                    <p>
+                        <span class="aui-icon aui-icon-small aui-iconfont-info"></span>
+                        $action.getText("ru.andreymarkelov.atlas.plugins.promconfluenceexporter.admin.settings.lastexecution") ${lastExecutionTimestamp}
+                    </p>
+                </div>
+            </div>
+        </header>
         <div>
+            #if ($saved)
+            <div class="aui-message closeable shadowed">
+                <p class="title">
+                    <span class="aui-icon icon-success"></span>
+                    <strong>$action.getText("ru.andreymarkelov.atlas.plugins.promconfluenceexporter.admin.settings.status.success")</strong>
+                </p>
+            </div>
+            #end
             <div id="base-form">
                 <form method="POST" action="savesettings.action" name="savesettings" class="aui">
                     #form_xsrfToken()
@@ -19,6 +43,12 @@
                         <div class="error" id="days-error">$action.getFieldErrors().get("token").get(0)</div>
                         #end
                         <div class="description">$action.getText("ru.andreymarkelov.atlas.plugins.promconfluenceexporter.admin.settings.token.desc")</div>
+                    </div>
+                    <div class="field-group">
+                        <label for="delay">$action.getText("ru.andreymarkelov.atlas.plugins.promconfluenceexporter.admin.settings.delay"):<span class="aui-icon icon-required">required</span></label>
+                        <input id="delay" name="delay" v-model="storedDelay" type="number" min=1 class="text">
+                        #if($action.getErrors().containsKey("delay"))<div class="error">$action.getErrors().get("delay")</div>#end
+                        <div class="description">$i18n.getText("ru.andreymarkelov.atlas.plugins.promconfluenceexporter.admin.settings.delay.desc")</div>
                     </div>
                     <div class="buttons-container">
                         <div class="buttons">
@@ -34,6 +64,7 @@
                 data() {
                     return {
                         storedToken: "$!{token}",
+                        storedDelay: "$!{delay}",
                         possible: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
                     }
                 },


### PR DESCRIPTION
Hi,
I tried to port the attachment size calculation of the Jira Prometheus Exporter to the Confluence Prometheus Exporter. 
I closely followed the solution implemented [here](https://github.com/AndreyVMarkelov/jira-prometheus-exporter/commit/8bff014f2751716b67a3b754e033ae7d78cb609a).

I hope this is useful!

Thanks!